### PR TITLE
fallback to formatted name

### DIFF
--- a/src/main/java/org/berkholz/vcard2fritzXML/Main.java
+++ b/src/main/java/org/berkholz/vcard2fritzXML/Main.java
@@ -227,8 +227,12 @@ public class Main {
             }
 
             Person p = new Person();
-            p.setRealName(vcardElement.getStructuredName().getGiven(), vcardElement.getStructuredName().getFamily(),
-                    cmdOptions.reversedOrder);
+            if (vcardElement.getStructuredName() != null) {
+                p.setRealName(vcardElement.getStructuredName().getGiven(), vcardElement.getStructuredName().getFamily(),
+                        cmdOptions.reversedOrder);
+            } else if(vcardElement.getFormattedName() != null) {
+                p.setRealName(vcardElement.getFormattedName().getValue());
+            }
             c1.setPerson(p);
 
             c1.setMod_time();


### PR DESCRIPTION
In my vcards (exported from [Nextcloud](https://github.com/nextcloud/server)) there are entries without structured name (N) and with formatted name (FN) only. In this case, a NullPointerException will be thrown in class Main, line 230.

In my optinion using the structured name in first step is correct to create the right order of the name parts. But we should add a fallback to the formatted name. This worked for me.